### PR TITLE
Use MosaicRasterSource to combine STAC Items in a collection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Addressed GeoTrellisRasterSourceLegacy issues and minimized number of RasterSource instances constructed for GeoTrellis Layers [#219](https://github.com/geotrellis/geotrellis-server/issues/219)
 - Some source resolutions are sometimes skipped leading to reading too much tiles [#215](https://github.com/geotrellis/geotrellis-server/issues/215)
+- LayerHistogram should select the CellSize large enough to compute the histogram [#261](https://github.com/geotrellis/geotrellis-server/pull/261)
 
 ## [4.1.0] - 2020-03-03
 

--- a/core/src/main/scala/geotrellis/server/LayerHistogram.scala
+++ b/core/src/main/scala/geotrellis/server/LayerHistogram.scala
@@ -77,7 +77,7 @@ object LayerHistogram {
         )
       }
       cellSize <- IO {
-        SampleUtils.chooseLargestCellSize(rasterExtents.map(_.cellSize))
+        SampleUtils.chooseLargestCellSize(rasterExtents, maxCells)
       }
       _ <- IO {
         logger.trace(


### PR DESCRIPTION
Still quite slow, but it works to combine all StacItemAssets that match the Repository Query into a single Mosaic that is then rendered via WCS.

@pomadchin is still working out threading issues with WMS/WMTS

Don't look too closely at the screenshot, I seem to have picked veeeery ugly landsat scenes.

![Screen Shot 2020-06-03 at 5 21 04 PM](https://user-images.githubusercontent.com/1818302/83690450-c246a380-a5be-11ea-8f36-8eef55870fa3.png)

Closes azavea/geotrellis#269
